### PR TITLE
Additional data fields to InfluxDB and Sharing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This tool is a wrapper for speedtest-cli which allows you to run periodic speedt
 #### SPEEDTEST
 |Key            |Description                                                                                                         |
 |:--------------|:-------------------------------------------------------------------------------------------------------------------|
-|Server         |Comma sperated list of servers.  Leave blank for auto                                                            |
+|Server         |Comma sperated list of servers.  Leave blank for auto                                                               |
+|Share          |Upload results to speedtest.net and retrieve url                                                                    |
 #### LOGGING
 |Key            |Description                                                                                                         |
 |:--------------|:-------------------------------------------------------------------------------------------------------------------|

--- a/config.ini
+++ b/config.ini
@@ -2,18 +2,18 @@
 Delay = 300
 
 [INFLUXDB]
-Address = 
+Address =
 Port = 8086
 Database = speedtests
-Username = 
-Password = 
+Username =
+Password =
 Verify_SSL = False
 
 [SPEEDTEST]
 # Leave blank to auto pick server
 Server =
 #if true speedtest result is posted to speedtest.net and url is returned
-Share = True 
+Share = False
 
 [LOGGING]
 # Valid Options: critical, error, warning, info, debug

--- a/config.ini
+++ b/config.ini
@@ -2,16 +2,18 @@
 Delay = 300
 
 [INFLUXDB]
-Address =
+Address = 
 Port = 8086
 Database = speedtests
-Username =
-Password =
+Username = 
+Password = 
 Verify_SSL = False
 
 [SPEEDTEST]
 # Leave blank to auto pick server
 Server =
+#if true speedtest result is posted to speedtest.net and url is returned
+Share = True 
 
 [LOGGING]
 # Valid Options: critical, error, warning, info, debug

--- a/influxspeedtest/InfluxdbSpeedtest.py
+++ b/influxspeedtest/InfluxdbSpeedtest.py
@@ -98,7 +98,7 @@ class InfluxdbSpeedtest():
                     'bytes_received': result_dict['bytes_received'],
                     'upload': result_dict['upload'],
                     'bytes_sent': result_dict['bytes_sent'],
-                    'latency': result_dict['server']['latency'],
+                    'ping': result_dict['server']['latency'],
                     'isp': result_dict['client']['isp'],
                     'server': result_dict['server']['id'],
                     'server_name': result_dict['server']['name'],

--- a/influxspeedtest/InfluxdbSpeedtest.py
+++ b/influxspeedtest/InfluxdbSpeedtest.py
@@ -94,37 +94,34 @@ class InfluxdbSpeedtest():
             {
                 'measurement': 'speed_test_results',
                 'fields': {
-                    'download': result_dict['download']['bandwidth'],
-                    'download_bytes': result_dict['download']['bytes'],
-                    'upload': result_dict['upload']['bandwidth'],
-                    'upload_bytes': result_dict['upload']['bytes'],
+                    'download': result_dict['download'],
+                    'bytes_received': result_dict['bytes_received'],
+                    'upload': result_dict['upload'],
+                    'bytes_sent': result_dict['bytes_sent'],
 
-                    'latency': result_dict['ping']['latency'],
-                    'jitter': result_dict['ping']['jitter'],
-                    'packetLoss': result_dict['packetLoss'],
+                    'latency': result_dict['ping'],
 
-                    'interface_internalIp': result_dict['interface']['internalIp'],
+                    'isp': result_dict['client']['isp'],
 
                     'server': result_dict['server']['id'],
                     'server_name': result_dict['server']['name'],
-                    'server_location': result_dict['server']['location'],
-                    'server_host': result_dict['server']['host'],
-
-                    'result': result_dict['result']['id'],
-                    'result_url':result_dict['result']['url']
+                    'server_country': result_dict['server']['country'],
+                    'server_sponsor': result_dict['server']['sponsor'],
+                    
+                    'result_url': result_dict['share']
                 },
                 'tags': {
                     'server': result_dict['server']['id'],
                     'server_name': result_dict['server']['name'],
                     'server_country': result_dict['server']['country'],
-                    'interface_internalIp': result_dict['interface']['internalIp']
+                    'isp': result_dict['client']['isp']
                 }
             }
         ]
 
         self.write_influx_data(input_points)
 
-    def run_speed_test(self, server=None):
+    def run_speed_test(self, server=None, share=False):
         """
         Performs the speed test with the provided server
         :param server: Server to test against
@@ -147,13 +144,16 @@ class InfluxdbSpeedtest():
         self.speedtest.download()
         log.info('Starting upload test')
         self.speedtest.upload()
+        if(share):
+            self.results.share()
         self.send_results()
 
         results = self.results.dict()
-        log.info('Download: %sMbps - Upload: %sMbps - Latency: %sms',
+        log.info('Download: %sMbps - Upload: %sMbps - Latency: %sms - Share: %s',
                  round(results['download'] / 1000000, 2),
                  round(results['upload'] / 1000000, 2),
-                 results['server']['latency']
+                 results['server']['latency'],
+                 results['share']
                  )
 
 
@@ -184,9 +184,9 @@ class InfluxdbSpeedtest():
 
         while True:
             if not config.servers:
-                self.run_speed_test()
+                self.run_speed_test(share=config.share)
             else:
                 for server in config.servers:
-                    self.run_speed_test(server)
+                    self.run_speed_test(server, config.share)
             log.info('Waiting %s seconds until next test', config.delay)
             time.sleep(config.delay)

--- a/influxspeedtest/InfluxdbSpeedtest.py
+++ b/influxspeedtest/InfluxdbSpeedtest.py
@@ -98,16 +98,12 @@ class InfluxdbSpeedtest():
                     'bytes_received': result_dict['bytes_received'],
                     'upload': result_dict['upload'],
                     'bytes_sent': result_dict['bytes_sent'],
-
-                    'latency': result_dict['ping'],
-
+                    'latency': result_dict['server']['latency'],
                     'isp': result_dict['client']['isp'],
-
                     'server': result_dict['server']['id'],
                     'server_name': result_dict['server']['name'],
                     'server_country': result_dict['server']['country'],
                     'server_sponsor': result_dict['server']['sponsor'],
-                    
                     'result_url': result_dict['share']
                 },
                 'tags': {

--- a/influxspeedtest/InfluxdbSpeedtest.py
+++ b/influxspeedtest/InfluxdbSpeedtest.py
@@ -94,16 +94,30 @@ class InfluxdbSpeedtest():
             {
                 'measurement': 'speed_test_results',
                 'fields': {
-                    'download': result_dict['download'],
-                    'upload': result_dict['upload'],
-                    'ping': result_dict['server']['latency'],
+                    'download': result_dict['download']['bandwidth'],
+                    'download_bytes': result_dict['download']['bytes'],
+                    'upload': result_dict['upload']['bandwidth'],
+                    'upload_bytes': result_dict['upload']['bytes'],
+
+                    'latency': result_dict['ping']['latency'],
+                    'jitter': result_dict['ping']['jitter'],
+                    'packetLoss': result_dict['packetLoss'],
+
+                    'interface_internalIp': result_dict['interface']['internalIp'],
+
                     'server': result_dict['server']['id'],
-                    'server_name': result_dict['server']['name']
+                    'server_name': result_dict['server']['name'],
+                    'server_location': result_dict['server']['location'],
+                    'server_host': result_dict['server']['host'],
+
+                    'result': result_dict['result']['id'],
+                    'result_url':result_dict['result']['url']
                 },
                 'tags': {
                     'server': result_dict['server']['id'],
                     'server_name': result_dict['server']['name'],
-                    'server_country': result_dict['server']['country']
+                    'server_country': result_dict['server']['country'],
+                    'interface_internalIp': result_dict['interface']['internalIp']
                 }
             }
         ]

--- a/influxspeedtest/config/configmanager.py
+++ b/influxspeedtest/config/configmanager.py
@@ -41,3 +41,4 @@ class ConfigManager():
         test_server = self.config['SPEEDTEST'].get('Server', fallback=None)
         if test_server:
             self.servers = test_server.split(',')
+        self.share = self.config['SPEEDTEST'].getboolean('Share', fallback=False)


### PR DESCRIPTION
Added mapping for the below and added config option for sharing. If Share=True result is uploaded to speedtest.net servers and a url is returned, useful for ISP troubleshooting.

- bytes_received
- bytes_sent
- isp (tag and field)
- server_sponsor
- result_url
